### PR TITLE
Add rule to ignore unused rest siblings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -50,6 +50,7 @@ module.exports = {
     "no-magic-numbers": [2, { "ignoreArrayIndexes": true, "ignore": ALLOWED_NUMBERS }],
     "no-use-before-define": 0,
     "no-underscore-dangle": ["error", { "allow": ["__PRELOADED_STATE__", "__APOLLO_STATE__"] }],
+    "no-unused-vars": ["error", { "ignoreRestSiblings": true, "argsIgnorePattern": "^_" }],
     "react/no-render-return-value": 0,
     "react/prop-types": 0, // No need for prop types with Typescript
     "react/jsx-max-props-per-line": [1, { "when": "multiline" }],


### PR DESCRIPTION
It's common we want to destructure an object in order to discard an entry, but the linter will complain that the discarded entry is unused, so this change will remove that issue.