### PR TITLE
Use strings for rule instead of number

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,11 +12,11 @@ module.exports = {
     'jsx-a11y/label-has-for': 'off', // This is deprecated but in the recommended extension for some reason
     'jsx-a11y/media-has-caption': 'off',
     'jsx-a11y/no-onchange': 'off',
-    'no-alert': 0,
+    'no-alert': 'error',
     'no-console': 'warn',
     'react-hooks/exhaustive-deps': 'error',
     'react-hooks/rules-of-hooks': 'error',
-    'react/jsx-filename-extension': [1, { 'extensions': ['.tsx', '.jsx'] }],
+    'react/jsx-filename-extension': ['warn', { 'extensions': ['.tsx', '.jsx'] }],
     'react/jsx-max-props-per-line': ['warn', { when: 'multiline' }],
     'react/no-render-return-value': 'off',
     'react/prop-types': 'off', // No need for prop types with Typescript


### PR DESCRIPTION
To keep things consistent.

Not related, but I noticed the last update added some new defaults that I think I'd like to change, so expect a PR on that once I get the time.