### PR TITLE
Disable react-in-jsx-scope rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,6 +19,7 @@ module.exports = {
     'react/jsx-max-props-per-line': ['warn', { when: 'multiline' }],
     'react/no-render-return-value': 'off',
     'react/prop-types': 'off', // No need for prop types with Typescript
+    'react/react-in-jsx-scope': 'off',
   },
   env: {
     browser: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "eslint-config-fishbrain",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-config-fishbrain",
-      "version": "5.0.5",
+      "version": "5.0.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^6.13.2",
         "@typescript-eslint/parser": "^6.13.2",
-        "eslint-config-fishbrain-base": "^5.0.2",
+        "eslint-config-fishbrain-base": "^5.0.5",
         "eslint-plugin-compat": "^4.2.0",
         "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-react": "^7.33.2",
@@ -2859,9 +2859,9 @@
       }
     },
     "node_modules/eslint-config-fishbrain-base": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/eslint-config-fishbrain-base/-/eslint-config-fishbrain-base-5.0.4.tgz",
-      "integrity": "sha512-gTylfdtf5BGNZC4KMqq1sUdgYmj8T24KY8azgKxEdQScuGyr5dEGVzPLP3WUlCNiUJDtd7zfVsWiBRWdLm61nA==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/eslint-config-fishbrain-base/-/eslint-config-fishbrain-base-5.0.5.tgz",
+      "integrity": "sha512-aQA34CYlbnzAKmViUUY8GGqmufbmqF1+wYvWmuoMV2v02ulVKAe7F8poZzrMaC+JVOtDtSV56LqWabpDS4Nj6Q==",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^6.13.2",
         "@typescript-eslint/parser": "^6.13.2",
@@ -8927,9 +8927,9 @@
       }
     },
     "eslint-config-fishbrain-base": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/eslint-config-fishbrain-base/-/eslint-config-fishbrain-base-5.0.4.tgz",
-      "integrity": "sha512-gTylfdtf5BGNZC4KMqq1sUdgYmj8T24KY8azgKxEdQScuGyr5dEGVzPLP3WUlCNiUJDtd7zfVsWiBRWdLm61nA==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/eslint-config-fishbrain-base/-/eslint-config-fishbrain-base-5.0.5.tgz",
+      "integrity": "sha512-aQA34CYlbnzAKmViUUY8GGqmufbmqF1+wYvWmuoMV2v02ulVKAe7F8poZzrMaC+JVOtDtSV56LqWabpDS4Nj6Q==",
       "requires": {
         "@typescript-eslint/eslint-plugin": "^6.13.2",
         "@typescript-eslint/parser": "^6.13.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^6.13.2",
     "@typescript-eslint/parser": "^6.13.2",
-    "eslint-config-fishbrain-base": "^5.0.2",
+    "eslint-config-fishbrain-base": "^5.0.5",
     "eslint-plugin-compat": "^4.2.0",
     "eslint-plugin-jsx-a11y": "^6.7.1",
     "eslint-plugin-react": "^7.33.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-fishbrain",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "description": "ESLint config for Fishbrain TypeScript projects",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This rule returns an error if a JSX file doesn't have:

```
import React from 'react';
```

Since React 18 (I think) this hasn't been needed. We can remove the rule and stop importing React.