### PR TITLE
Include .mts and .cts in react-hooks files pattern

### DIFF
--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -29,7 +29,7 @@ const reactConfig = [
   jsxA11yPlugin.flatConfigs.recommended,
   compatPlugin.configs['flat/recommended'],
   {
-    files: ['**/**/*.{js,ts,jsx,tsx}'],
+    files: ['**/**/*.{js,ts,mts,cts,jsx,tsx}'],
     plugins: {
       'react-hooks': pluginReactHooks,
     },


### PR DESCRIPTION
## Summary
- The `react-hooks` plugin in `packages/react/index.js` was registered with `files: ['**/**/*.{js,ts,jsx,tsx}']`, but the sibling `customRules` block references `react-hooks/exhaustive-deps` and `react-hooks/rules-of-hooks` without any `files` scope. Linting a `.mts` or `.cts` file matches `customRules` but not the plugin block, producing: `A configuration object specifies rule "react-hooks/exhaustive-deps", but could not find plugin "react-hooks"`.
- This surfaced in `mykiss-web` after `next.config.js` and `unicode-city-slug-redirects.ts` were migrated to `.mts` (FIB-50776).
- Fix: add `mts,cts` to the plugin block's `files` pattern so the plugin namespace is registered for those files too.

## Test plan
- [x] Verified locally by copying the patched `index.js` into `mykiss-web/node_modules/@fishbrain/eslint-config-react/` and running `yarn lint` — passes (previously errored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)