### PR TITLE
FIB-50939: publish to npmjs.org instead of yarnpkg.com mirror

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,5 +17,7 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
-      - run: yarn config set npmAuthToken "${{ secrets.NPM_TOKEN }}"
-      - run: yarn publish
+      - run: |
+          yarn config set 'npmRegistries["https://registry.npmjs.org"].npmAuthToken' "${{ secrets.NPM_TOKEN }}"
+          yarn config set 'npmRegistries["https://registry.npmjs.org"].npmAlwaysAuth' true
+      - run: yarn run publish

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,2 @@
 nodeLinker: node-modules
+npmPublishRegistry: "https://registry.npmjs.org"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/fishbrain/eslint-config-fishbrain#readme",
   "scripts": {
-    "publish": "yarn workspaces foreach -A --include \"packages/**\" npm publish --access public",
+    "publish": "yarn workspaces foreach -A --no-private npm publish --access public --tolerate-republish",
     "test": "yarn workspaces foreach --all run test"
   },
   "prettier": {


### PR DESCRIPTION
## Why

The Publish workflow has been failing on `yarn publish` with:

```
➤ YN0035: Not found
➤ YN0035:   Response Code: 404 (Not Found)
➤ YN0035:   Request Method: PUT
➤ YN0035:   Request URL: https://registry.yarnpkg.com/@fishbrain%2feslint-config-base
```

`registry.yarnpkg.com` is the **read-only npm proxy** — it serves `GET`s but rejects `PUT`s, hence the 404. Yarn 4's `yarn npm publish` resolves the publish URL in this order: `npmPublishRegistry` → `npmRegistryServer` → fallback to `registry.yarnpkg.com`. Neither was set, so it fell through to the proxy. The token was also stored globally (`yarn config set npmAuthToken …`), which Yarn only applies to the registry matching `npmRegistryServer` — so the token has to be re-bound to the publish host as well.

## What

- **`.yarnrc.yml`** — pin the publish target with `npmPublishRegistry: "https://registry.npmjs.org"`.
- **`.github/workflows/publish.yml`** — bind the auth token to `registry.npmjs.org` and call `yarn run publish` explicitly so the script runs unambiguously (instead of relying on the no-op-in-Yarn-4 `yarn publish` falling through to the script).
- **`package.json`** — replace the broken `--include "packages/**"` glob (which filters by workspace **name**, not path, so it matched nothing useful) with `--no-private`, and add `--tolerate-republish` so reruns after a partial failure are idempotent.

## Verification

Locally:

```
yarn workspaces foreach -A --no-private --dry-run npm publish --access public
```

Confirms the root monorepo workspace is excluded and only `eslint-config-base` and `eslint-config-react` are selected.

Refs: https://fishbrain.atlassian.net/browse/FIB-50939

🤖 Generated with [Claude Code](https://claude.com/claude-code)