### PR TITLE
Go Live

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,5 +17,7 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
-      - run: yarn config set npmAuthToken "${{ secrets.NPM_TOKEN }}"
-      - run: yarn publish
+      - run: |
+          yarn config set 'npmRegistries["https://registry.npmjs.org"].npmAuthToken' "${{ secrets.NPM_TOKEN }}"
+          yarn config set 'npmRegistries["https://registry.npmjs.org"].npmAlwaysAuth' true
+      - run: yarn run publish

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,2 @@
 nodeLinker: node-modules
+npmPublishRegistry: "https://registry.npmjs.org"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/fishbrain/eslint-config-fishbrain#readme",
   "scripts": {
-    "publish": "yarn workspaces foreach -A --include \"packages/**\" npm publish --access public",
+    "publish": "yarn workspaces foreach -A --no-private npm publish --access public --tolerate-republish",
     "test": "yarn workspaces foreach --all run test"
   },
   "prettier": {

--- a/package.json
+++ b/package.json
@@ -24,5 +24,5 @@
     "singleQuote": true,
     "trailingComma": "all"
   },
-  "packageManager": "yarn@4.13.0"
+  "packageManager": "yarn@4.14.1"
 }

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fishbrain/eslint-config-base",
-  "packageManager": "yarn@4.13.0",
+  "packageManager": "yarn@4.14.1",
   "version": "6.3.6",
   "type": "module",
   "exports": "./index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fishbrain/eslint-config-react",
-  "packageManager": "yarn@4.13.0",
+  "packageManager": "yarn@4.14.1",
   "version": "6.3.6",
   "type": "module",
   "exports": "./index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -21,7 +21,7 @@
     "eslint-plugin-react": "7.37.5",
     "eslint-plugin-react-hooks": "7.1.1",
     "eslint-plugin-testing-library": "7.16.2",
-    "globals": "17.4.0",
+    "globals": "17.5.0",
     "typescript-eslint": "8.59.1"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 8
+  version: 9
   cacheKey: 10c0
 
 "@ampproject/remapping@npm:^2.2.0":

--- a/yarn.lock
+++ b/yarn.lock
@@ -4044,9 +4044,9 @@ __metadata:
   linkType: hard
 
 "flatted@npm:^3.2.9":
-  version: 3.3.1
-  resolution: "flatted@npm:3.3.1"
-  checksum: 10c0/324166b125ee07d4ca9bcf3a5f98d915d5db4f39d711fba640a3178b959919aae1f7cfd8aabcfef5826ed8aa8a2aa14cc85b2d7d18ff638ddf4ae3df39573eaf
+  version: 3.4.2
+  resolution: "flatted@npm:3.4.2"
+  checksum: 10c0/a65b67aae7172d6cdf63691be7de6c5cd5adbdfdfe2e9da1a09b617c9512ed794037741ee53d93114276bff3f93cd3b0d97d54f9b316e1e4885dde6e9ffdf7ed
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6398,9 +6398,9 @@ __metadata:
   linkType: hard
 
 "picomatch@npm:^2.0.4, picomatch@npm:^2.3.1":
-  version: 2.3.1
-  resolution: "picomatch@npm:2.3.1"
-  checksum: 10c0/26c02b8d06f03206fc2ab8d16f19960f2ff9e81a658f831ecb656d8f17d9edc799e8364b1f4a7873e89d9702dff96204be0fa26fe4181f6843f040f819dac4be
+  version: 2.3.2
+  resolution: "picomatch@npm:2.3.2"
+  checksum: 10c0/a554d1709e59be97d1acb9eaedbbc700a5c03dbd4579807baed95100b00420bc729335440ef15004ae2378984e2487a7c1cebd743cfdb72b6fa9ab69223c0d61
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -921,7 +921,7 @@ __metadata:
     eslint-plugin-react: "npm:7.37.5"
     eslint-plugin-react-hooks: "npm:7.1.1"
     eslint-plugin-testing-library: "npm:7.16.2"
-    globals: "npm:17.4.0"
+    globals: "npm:17.5.0"
     react: "npm:19.2.5"
     typescript: "npm:5.9.3"
     typescript-eslint: "npm:8.59.1"
@@ -4335,10 +4335,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globals@npm:17.4.0":
-  version: 17.4.0
-  resolution: "globals@npm:17.4.0"
-  checksum: 10c0/2be9e8c2b9035836f13d420b22f0247a328db82967d3bebfc01126d888ed609305f06c05895914e969653af5c6ba35fd7a0920f3e6c869afa60666c810630feb
+"globals@npm:17.5.0":
+  version: 17.5.0
+  resolution: "globals@npm:17.5.0"
+  checksum: 10c0/92828102ed2f5637907725f0478038bed02fc83e9fc89300bb753639ba7c022b6c02576fc772117302b431b204591db1f2fa909d26f3f0a9852cc856a941df3f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Merged PRs

### @renovate[bot]

* #894 - Update Yarn to v4.14.1 (@lhansford merged)
* #891 - Update dependency globals to v17.5.0 (@lhansford merged)

### @dependabot[bot]

* #904 - Bump picomatch from 2.3.1 to 2.3.2 (@lhansford merged)
* #903 - Bump flatted from 3.3.1 to 3.4.2 (@lhansford merged)

### @alexanderbergstrom-fishbrain

* #905 - FIB-50939: publish to npmjs.org instead of yarnpkg.com mirror



