### PR TITLE
FIB-50939: install deps before pack-and-publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,9 @@ jobs:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Install
+        run: yarn install --immutable
+
       - name: Pack and publish each workspace
         run: |
           set -euo pipefail


### PR DESCRIPTION
The OIDC publish run failed with `Couldn't find the node_modules state file` — `yarn workspaces foreach exec` needs the install state to enumerate workspaces. Adding `yarn install --immutable` back into the publish job.

Refs: https://fishbrain.atlassian.net/browse/FIB-50939

🤖 Generated with [Claude Code](https://claude.com/claude-code)