### PR TITLE
FIB-50939: use ubuntu-latest for publish runner

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,9 @@ permissions:
 
 jobs:
   publish:
-    runs-on: warp-ubuntu-latest-x64-2x
+    # Must run on a GitHub-hosted runner — npm's trusted-publisher OIDC
+    # exchange and `--provenance` attestations both require it.
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 


### PR DESCRIPTION
Switch the publish job from the Warp-hosted runner to GitHub's `ubuntu-latest`.

Refs: https://fishbrain.atlassian.net/browse/FIB-50939

🤖 Generated with [Claude Code](https://claude.com/claude-code)