### PR TITLE
FIB-50939: set repository on workspace package.jsons

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -4,6 +4,11 @@
   "version": "6.3.6",
   "type": "module",
   "exports": "./index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fishbrain/eslint-config-fishbrain.git",
+    "directory": "packages/base"
+  },
   "scripts": {
     "test": "eslint index.js eslint.config.js"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -4,6 +4,11 @@
   "version": "6.3.6",
   "type": "module",
   "exports": "./index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fishbrain/eslint-config-fishbrain.git",
+    "directory": "packages/react"
+  },
   "scripts": {
     "test": "eslint index.js eslint.config.js"
   },


### PR DESCRIPTION
Publish failed with `422 Unprocessable Entity - Error verifying sigstore provenance bundle: "repository.url" is ""`. npm verifies the packed package.json's repository URL matches the OIDC claim. The workspaces had no `repository` field of their own, so the check failed.

Refs: https://fishbrain.atlassian.net/browse/FIB-50939

🤖 Generated with [Claude Code](https://claude.com/claude-code)