### PR TITLE
FIB-51490: Scope testing-library plugin to test files only

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fishbrain/eslint-config-monorepo",
   "private": true,
   "description": "ESLint configs for Fishbrain projects",
-  "version": "6.3.6",
+  "version": "6.3.7",
   "workspaces": [
     "packages/*"
   ],

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fishbrain/eslint-config-base",
   "packageManager": "yarn@4.15.0",
-  "version": "6.3.6",
+  "version": "6.3.7",
   "type": "module",
   "exports": "./index.js",
   "repository": {

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -37,7 +37,13 @@ const reactConfig = [
   },
 ];
 
-const testingConfig = [testingLibraryPlugin.configs['flat/react']];
+// Scope the testing-library plugin to test files only
+const testingConfig = [
+  {
+    files: ['**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[jt]s?(x)'],
+    ...testingLibraryPlugin.configs['flat/react'],
+  },
+];
 
 const customRules = {
   rules: {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fishbrain/eslint-config-react",
   "packageManager": "yarn@4.15.0",
-  "version": "6.3.6",
+  "version": "6.3.7",
   "type": "module",
   "exports": "./index.js",
   "repository": {


### PR DESCRIPTION
## Summary

`@fishbrain/eslint-config-react` applied `eslint-plugin-testing-library`'s `flat/react` preset with **no `files` restriction**, so it linted the entire codebase — not just tests. That produces false positives in source, e.g. our own `logger.debug(...)` flagged by `testing-library/no-debugging-utils` as if it were `screen.debug()`.

This scopes the plugin to test files only, following the plugin's [official recommendation](https://github.com/testing-library/eslint-plugin-testing-library#run-the-plugin-only-against-test-files):

```js
const testingConfig = [
  {
    files: ['**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[jt]s?(x)'],
    ...testingLibraryPlugin.configs['flat/react'],
  },
];
```

Version bumped 6.3.6 → 6.3.7 (all three package.json files, per the repo's lockstep convention).

## Verification

`calculateConfigForFile` confirms `testing-library/*` rules are now active **only** on test files:

| File | `no-debugging-utils` |
|------|----------------------|
| `src/foo.ts` | NOT ACTIVE |
| `src/foo.test.tsx` | active (warn) |
| `src/__tests__/bar.ts` | active (warn) |

Workspace tests pass (`yarn workspaces foreach --all run test`).

## Downstream

Once 6.3.7 is published, consumers ("mykiss and friends") can bump and will lose the false positives. In mykiss-web specifically this also unblocks removing the `testing-library/render-result-naming-convention: 'off'` workaround (whose comment cites this exact "plugin runs against all files" limitation).

Part of [FIB-35810](https://fishbrain.atlassian.net/browse/FIB-35810) → [FIB-51490](https://fishbrain.atlassian.net/browse/FIB-51490).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[FIB-35810]: https://fishbrain.atlassian.net/browse/FIB-35810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ